### PR TITLE
Grant write permissions to group

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 FROM registry.access.redhat.com/ubi8/nginx-118
 
+USER root
+
+# Grant write permission to group
+RUN chmod -R g+w /opt/app-root/src /usr/local/bin/
+
+USER 1001
+
 # Copy configuration scripts
 COPY --chown=1001:0 build/configs/notify-gchat.sh /usr/local/bin/notify-gchat.sh
 


### PR DESCRIPTION
This is required since openshift runs the image as any random user, but the user is part of root group. Granting write access to group will avoid permission denied issues.