### PR TITLE
Fix bug where the design detail panel does not load when there is no `origin` field defined. 

### DIFF
--- a/src/app/pages/components/home/design-events.tsx
+++ b/src/app/pages/components/home/design-events.tsx
@@ -21,23 +21,23 @@ export const DesignEvents: FunctionComponent<DesignEventsProps> = ({design}: Des
     const designsService: DesignsService = useDesignsService();
 
     const originGroupId = (): string => {
-        return design?.origin.rhosr?.groupId || "default";
+        return design?.origin?.rhosr?.groupId || "default";
     };
     const originArtifactId = (): string => {
-        return design?.origin.rhosr?.artifactId || "Unknown";
+        return design?.origin?.rhosr?.artifactId || "Unknown";
     };
     const originVersion = (): string => {
-        return design?.origin.rhosr?.version || "latest";
+        return design?.origin?.rhosr?.version || "latest";
     };
     const originFilename = (): string => {
-        return design?.origin.file?.fileName || "";
+        return design?.origin?.file?.fileName || "";
     };
     const originUrl = (): string => {
-        return design?.origin.url?.url || "";
+        return design?.origin?.url?.url || "";
     };
 
     useEffect(() => {
-        if (design) {
+        if (design) {            
             designsService.getEvents(design.id).then(events => {
                 setExports(events?.filter(event => event.type === "download" || event.type === "register"));
                 setLoading(false);

--- a/src/app/pages/components/home/design-events.tsx
+++ b/src/app/pages/components/home/design-events.tsx
@@ -37,7 +37,7 @@ export const DesignEvents: FunctionComponent<DesignEventsProps> = ({design}: Des
     };
 
     useEffect(() => {
-        if (design) {            
+        if (design) {
             designsService.getEvents(design.id).then(events => {
                 setExports(events?.filter(event => event.type === "download" || event.type === "register"));
                 setLoading(false);

--- a/src/app/pages/components/home/design-list.tsx
+++ b/src/app/pages/components/home/design-list.tsx
@@ -8,7 +8,6 @@ import {KebabToggle, Label} from "@patternfly/react-core";
 import {IAction} from "@patternfly/react-table";
 import {ThProps} from "@patternfly/react-table/src/components/TableComposable/Th";
 import {CustomActionsToggleProps} from "@patternfly/react-table/src/components/Table/ActionsColumn";
-import {hasOrigin} from "@app/utils";
 import {DesignOriginLabel} from "@app/pages/components";
 
 
@@ -72,13 +71,12 @@ export const DesignList: FunctionComponent<DesignListProps> = (
 
     const actionsFor = (design: any): IAction[] => {
         return [
-            { title: "View details", onClick: () => setSelectedDesign(design) },
-            { isSeparator: true, },
+            { title: "Details", onClick: () => setSelectedDesign(design) },
             { title: "Rename", onClick: () => onRename(design) },
             { title: "Edit", onClick: () => onEdit(design) },
             { title: "Download", onClick: () => onDownload(design) },
             { title: "Register in Service Registry", onClick: () => onRegister(design) },
-            { isSeparator: true, },
+            { isSeparator: true},
             { title: "Delete", onClick: () => onDelete(design) }
         ];
     }
@@ -119,7 +117,6 @@ export const DesignList: FunctionComponent<DesignListProps> = (
                 columns={columns}
                 data={designs.designs}
                 expectedLength={designs.count}
-                onRowClick={(row) => setSelectedDesign(row.row.id === selectedDesign?.id ? undefined : row.row)}
                 renderHeader={({ column, Th, key }) => (
                     <Th sort={sortParams(column)}
                         className="design-list-header"

--- a/src/app/pages/components/home/design-list.tsx
+++ b/src/app/pages/components/home/design-list.tsx
@@ -76,7 +76,6 @@ export const DesignList: FunctionComponent<DesignListProps> = (
             { title: "Edit", onClick: () => onEdit(design) },
             { title: "Download", onClick: () => onDownload(design) },
             { title: "Register in Service Registry", onClick: () => onRegister(design) },
-            { isSeparator: true},
             { title: "Delete", onClick: () => onDelete(design) }
         ];
     }
@@ -124,6 +123,7 @@ export const DesignList: FunctionComponent<DesignListProps> = (
                         width={column.width}
                         modifier="truncate">{column.label}</Th>
                 )}
+                onRowClick={({ row }) => setSelectedDesign(row)}
                 renderCell={({ column, row, colIndex, Td, key }) => (
                     <Td className="design-list-cell" key={`cell-${colIndex}-${row.id}`} children={renderColumnData(row as Design, colIndex)} />
                 )}


### PR DESCRIPTION
The detail panel does not load when the origin field is undefined on a design. This fixes that.

Additionally, I have moved the action button to the actions list to open this panel. The current way is not obvious that you must click the list item outside of the text link.