### PR TITLE
fix: append dropdown to modal element by its ID

### DIFF
--- a/src/app/components/object-select.tsx
+++ b/src/app/components/object-select.tsx
@@ -16,13 +16,14 @@ export type ObjectSelectProps = {
     itemToString: (value: any) => string;
     noSelectionLabel?: string;
     menuAppendTo?: HTMLElement | (() => HTMLElement) | 'parent' | 'inline';
+    variant?: 'single' | 'checkbox' | 'typeahead' | 'typeaheadmulti';
 };
 
 /**
  * A generic control that makes it easier to create a <Select> from an array of objects.
  */
 export const ObjectSelect: FunctionComponent<ObjectSelectProps> = (
-    {value, items, onSelect, itemToString, noSelectionLabel, menuAppendTo}: ObjectSelectProps) => {
+    {value, items, onSelect, itemToString, noSelectionLabel, menuAppendTo, variant}: ObjectSelectProps) => {
 
     const [isToggled, setToggled] = useState<boolean>(false);
     const [selectObjects, setSelectObjects] = useState<ObjectSelectOptionObject[]>();
@@ -64,7 +65,7 @@ export const ObjectSelect: FunctionComponent<ObjectSelectProps> = (
     }, [value]);
 
     return (
-        <Select menuAppendTo={menuAppendTo} variant={SelectVariant.single} onToggle={setToggled} onSelect={onSelectInternal} isOpen={isToggled} selections={selections}>
+        <Select menuAppendTo={menuAppendTo} variant={variant || SelectVariant.single} onToggle={setToggled} onSelect={onSelectInternal} isOpen={isToggled} selections={selections}>
             {
                 selectObjects?.map((soo, index) => (
                     <SelectOption isPlaceholder={soo.item === undefined} key={index} value={soo} />

--- a/src/app/pages/components/home/artifact-list-toolbar.tsx
+++ b/src/app/pages/components/home/artifact-list-toolbar.tsx
@@ -2,6 +2,9 @@ import React, {FunctionComponent, useEffect, useState} from "react";
 import "./artifact-list-toolbar.css";
 import {
     Button,
+    Dropdown,
+    DropdownItem,
+    DropdownToggle,
     OnPerPageSelect,
     OnSetPage,
     Pagination,
@@ -27,6 +30,7 @@ export type ArtifactListToolbarProps = {
     criteria: ArtifactListToolbarCriteria;
     paging: Paging;
     artifacts?: ArtifactSearchResults;
+    menuAppendTo?: HTMLElement | (() => HTMLElement) | 'parent' | 'inline' | undefined | null;
     onRegistrySelected: (registry: Registry) => void;
     onCriteriaChange: (criteria: ArtifactListToolbarCriteria) => void;
     onPagingChange: (paging: Paging) => void;
@@ -34,7 +38,7 @@ export type ArtifactListToolbarProps = {
 
 
 export const ArtifactListToolbar: FunctionComponent<ArtifactListToolbarProps> = ({registries, criteria, onCriteriaChange, paging,
-                                                                            onPagingChange, artifacts, onRegistrySelected}: ArtifactListToolbarProps) => {
+                                                                            onPagingChange, artifacts, onRegistrySelected, menuAppendTo}: ArtifactListToolbarProps) => {
     const [ registry, setRegistry ] = useState<Registry>();
     const [ filterValue, setFilterValue ] = useState(criteria.filterValue);
 
@@ -104,7 +108,7 @@ export const ArtifactListToolbar: FunctionComponent<ArtifactListToolbarProps> = 
                 <ToolbarItem variant="search-filter">
                     <ObjectSelect value={registry} items={registries}
                                   onSelect={onRegistrySelectInternal}
-                                  menuAppendTo="parent"
+                                  menuAppendTo={menuAppendTo || 'parent'}
                                   itemToString={item => item.name} />
                 </ToolbarItem>
                 <ToolbarItem variant="search-filter">

--- a/src/app/pages/components/home/artifact-list-toolbar.tsx
+++ b/src/app/pages/components/home/artifact-list-toolbar.tsx
@@ -9,6 +9,7 @@ import {
     OnSetPage,
     Pagination,
     SearchInput,
+    SelectVariant,
     Toolbar,
     ToolbarContent,
     ToolbarItem
@@ -107,6 +108,7 @@ export const ArtifactListToolbar: FunctionComponent<ArtifactListToolbarProps> = 
             <ToolbarContent>
                 <ToolbarItem variant="search-filter">
                     <ObjectSelect value={registry} items={registries}
+                                  variant={SelectVariant.typeahead}
                                   onSelect={onRegistrySelectInternal}
                                   menuAppendTo={menuAppendTo || 'parent'}
                                   itemToString={item => item.name} />

--- a/src/app/pages/components/home/artifact-selector.tsx
+++ b/src/app/pages/components/home/artifact-selector.tsx
@@ -106,6 +106,7 @@ export const ArtifactSelector: FunctionComponent<ArtifactSelectorProps> = ({regi
     const toolbar: React.ReactNode = (
         <ArtifactListToolbar registries={registries} criteria={criteria} paging={paging}
                              onRegistrySelected={onRegistrySelected}
+                             menuAppendTo={document.getElementById('artifact-selector')}
                              onCriteriaChange={onCriteriaChange} onPagingChange={onPagingChange}
                              artifacts={artifacts} />
     );
@@ -130,18 +131,19 @@ export const ArtifactSelector: FunctionComponent<ArtifactSelectorProps> = ({regi
 
     return (
         <div id="artifact-selector">
-            <ArtifactListToolbar registries={registries} criteria={criteria} paging={paging}
-                                 onRegistrySelected={onRegistrySelected}
-                                 menuAppendTo={document.getElementById('artifact-selector')}
-                                 onCriteriaChange={onCriteriaChange} onPagingChange={onPagingChange}
-                                 artifacts={artifacts} />
-            <IsLoading condition={querying}>
-                <IfNotEmpty collection={artifacts?.artifacts} emptyStateMessage={`No artifacts found matching the search criteria.`}>
-                    <ArtifactList artifacts={artifacts?.artifacts} fetchArtifactContent={fetchArtifactContent}
-                                  onArtifactSelected={onArtifactSelected}
-                                  fetchArtifactVersions={fetchArtifactVersions} />
-                </IfNotEmpty>
-            </IsLoading>
+            <ListWithToolbar toolbar={toolbar}
+                alwaysShowToolbar={true}
+                emptyState={emptyState}
+                filteredEmptyState={filteredEmptyState}
+                isFiltered={criteria.filterValue !== ""}
+                isLoading={querying}
+                loadingComponent={loadingComponent}
+                isEmpty={!artifacts || artifacts.count === 0}
+            >
+                <ArtifactList artifacts={artifacts?.artifacts} fetchArtifactContent={fetchArtifactContent}
+                    onArtifactSelected={onArtifactSelected}
+                    fetchArtifactVersions={fetchArtifactVersions} />
+            </ListWithToolbar>
         </div>
     );
 };

--- a/src/app/pages/components/home/artifact-selector.tsx
+++ b/src/app/pages/components/home/artifact-selector.tsx
@@ -10,7 +10,7 @@ import {
 } from "@app/models";
 import {RhosrInstanceService, RhosrInstanceServiceFactory, useRhosrInstanceServiceFactory} from "@app/services";
 import {ArtifactList, ArtifactListToolbar, ArtifactListToolbarCriteria} from "@app/pages/components";
-import {ListWithToolbar} from "@app/components";
+import {IfNotEmpty, IsLoading, ListWithToolbar} from "@app/components";
 import {EmptyState, EmptyStateBody, EmptyStateVariant, Spinner, Title} from "@patternfly/react-core";
 
 /**
@@ -129,18 +129,19 @@ export const ArtifactSelector: FunctionComponent<ArtifactSelectorProps> = ({regi
     );
 
     return (
-        <ListWithToolbar toolbar={toolbar}
-                         alwaysShowToolbar={true}
-                         emptyState={emptyState}
-                         filteredEmptyState={filteredEmptyState}
-                         isFiltered={criteria.filterValue !== ""}
-                         isLoading={querying}
-                         loadingComponent={loadingComponent}
-                         isEmpty={!artifacts || artifacts.count === 0}
-        >
-            <ArtifactList artifacts={artifacts?.artifacts} fetchArtifactContent={fetchArtifactContent}
-                          onArtifactSelected={onArtifactSelected}
-                          fetchArtifactVersions={fetchArtifactVersions} />
-        </ListWithToolbar>
+        <div id="artifact-selector">
+            <ArtifactListToolbar registries={registries} criteria={criteria} paging={paging}
+                                 onRegistrySelected={onRegistrySelected}
+                                 menuAppendTo={document.getElementById('artifact-selector')}
+                                 onCriteriaChange={onCriteriaChange} onPagingChange={onPagingChange}
+                                 artifacts={artifacts} />
+            <IsLoading condition={querying}>
+                <IfNotEmpty collection={artifacts?.artifacts} emptyStateMessage={`No artifacts found matching the search criteria.`}>
+                    <ArtifactList artifacts={artifacts?.artifacts} fetchArtifactContent={fetchArtifactContent}
+                                  onArtifactSelected={onArtifactSelected}
+                                  fetchArtifactVersions={fetchArtifactVersions} />
+                </IfNotEmpty>
+            </IsLoading>
+        </div>
     );
 };

--- a/src/app/pages/components/shared/export-to-rhosr.modal.tsx
+++ b/src/app/pages/components/shared/export-to-rhosr.modal.tsx
@@ -1,6 +1,6 @@
 import React, {FunctionComponent, useEffect, useState} from "react";
 import "./export-to-rhosr.modal.css";
-import {Button, Form, FormGroup, Modal, ModalVariant, Spinner, TextInput} from "@patternfly/react-core";
+import {Button, Form, FormGroup, Modal, ModalVariant, SelectVariant, Spinner, TextInput} from "@patternfly/react-core";
 import {Design, DesignEvent} from "@app/models";
 import {Registry} from "@rhoas/registry-management-sdk";
 import {
@@ -173,6 +173,7 @@ export const ExportToRhosrModal: FunctionComponent<ExportToRhosrModalProps> = (
                     <FormGroup label="Registry Instance" isRequired={true} fieldId="export-registry-instance">
                         <ObjectSelect value={registry} items={registries}
                                       onSelect={onRegistrySelect}
+                                      variant={SelectVariant.typeahead}
                                       menuAppendTo="parent"
                                       itemToString={item => item.name} />
                     </FormGroup>


### PR DESCRIPTION
In the **Import from Service Registry** modal the dropdown was not properly appending to the modal, probably because it was nested inside a couple of components.

This fixes that.

I have also made it so that you can filter down the list of registries if it is large.

**Before**
![Screenshot 2022-06-21 at 15 46 59](https://user-images.githubusercontent.com/11743717/174830022-edc7b649-c136-4b70-8490-139b96b77d60.png)

**After**
![Screenshot 2022-06-21 at 16 06 31](https://user-images.githubusercontent.com/11743717/174833635-13385760-dde6-49c7-b97b-b2c49bb0fc5c.png)


